### PR TITLE
Minor fixup for "unwrap" & add a dependency note in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@ Julia
 =====
 A parallel realtime Julia set renderer in Rust
 
+Dependencies
+--------
+Requires the SDL2 library. This can be installed via most package managers or you can build from source by following the instructions at https://wiki.libsdl.org/Installation.
+
+If you are on MacOS and have [Homebrew](https://brew.sh/), you can do `brew install sdl2`.
+
 Controls
 --------
 * Move the mouse to define the key point of the Julia set.

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,7 +85,7 @@ fn main() {
         renderer.copy(&texture, None, None).expect("Copied texture");
         renderer.present();
         // Copy the texture into both buffers
-        renderer.copy(&texture, None, None).unwrap("Copied texture");
+        renderer.copy(&texture, None, None).expect("Copied texture");
 
         let mut ready_to_break = true;
         let mut next_event: Option<Event> = None;


### PR DESCRIPTION
This should allow people to set up and run this repo without experiencing as many small hiccups in the build process.